### PR TITLE
readjust the order of arguments in the docs

### DIFF
--- a/source/gear/input/Input.hx
+++ b/source/gear/input/Input.hx
@@ -18,8 +18,8 @@ class Input
 
 	/**
 	 * Reads an internal input file.
-	 * @param inputFile The path to the input configuration JSON file.
 	 * @param stage The OpenFL Stage to attach event listeners to. If null, FlxG.stage is used.
+	 * @param inputFile The path to the input configuration JSON file.
 	 */
 	public function new(?stage:Stage, inputFile:String)
 	{


### PR DESCRIPTION
i sort of noticed that in the documentation above the new contructor inside of Input, the order of the arguments are swapped.
thats why this pr exists lol
feel free to check the changes